### PR TITLE
Drop trailing commas from slocum_dac.json

### DIFF
--- a/gutils/templates/slocum_dac.json
+++ b/gutils/templates/slocum_dac.json
@@ -349,7 +349,7 @@
         "ioos_category": "Currents",
         "coordinates": "lon_uv lat_uv time_uv",
         "colorBarMaximum": { "type": "double", "data": 0.5},
-        "colorBarMinimum": { "type": "double", "data": -0.5},
+        "colorBarMinimum": { "type": "double", "data": -0.5}
       }
     },
     "v": {
@@ -367,7 +367,7 @@
         "ioos_category": "Currents",
         "coordinates": "lon_uv lat_uv time_uv",
         "colorBarMaximum": { "type": "double", "data": 0.5},
-        "colorBarMinimum": { "type": "double", "data": -0.5},
+        "colorBarMinimum": { "type": "double", "data": -0.5}
       }
     },
     "u_orig": {


### PR DESCRIPTION
This PR fixes the failing `test_real_deployments` test for deployment `unit_191-20210323T0000`.