### PR TITLE
Move the "extras" data to be in their own profile netCDF file

### DIFF
--- a/gutils/filters.py
+++ b/gutils/filters.py
@@ -2,7 +2,6 @@
 # coding=utf-8
 import os
 import pandas as pd
-import numpy as np
 
 from gutils.yo import assign_profiles
 
@@ -177,23 +176,9 @@ def process_dataset(file,
                     tolerance=pd.Timedelta(minutes=10)
                 ).set_index(extras.index)
                 extras['profile'] = merge.profile.ffill()
-
-                # To have consistent netCDF files, empty "extras" variables need to exist
-                # in for each valid profile that was calculated above into "filtered".
-                profile_list = set(filtered['profile'].unique())
-                extras_list = set(extras['profile'].unique().astype('int32'))
-                profiles_to_add = profile_list.difference(extras_list)
-                if profiles_to_add:
-                    first_t_in_profiles = filtered.groupby(by=["profile"]).min()['t']
-                    for profile_to_add in profiles_to_add:
-                        empty_df = pd.DataFrame([[np.nan] * len(extras.columns)], columns=extras.columns)
-                        empty_df['profile'] = profile_to_add
-                        empty_df['pseudogram_time'] = first_t_in_profiles[profile_to_add]
-                        empty_df.set_index('pseudogram_time', inplace=True)
-                        extras = pd.concat([extras, empty_df], sort=True)
-
             except BaseException as e:
                 L.error(f"Could not merge 'extras' data, skipping: {e}")
+                extras = pd.DataFrame()
 
     except ValueError as e:
         L.exception('{} - Skipping'.format(e))

--- a/gutils/templates/slocum_dac.json
+++ b/gutils/templates/slocum_dac.json
@@ -1005,32 +1005,8 @@
         "_FillValue": {"type": "float", "data": -9999.9}
       }
     },
-    "pseudogram_time": {
-      "type": "double",
-      "attributes": {
-        "long_name": "Pseudogram Time",
-        "ioos_category": "Other",
-        "standard_name": "pseudogram_time",
-        "platform": "platform",
-        "observation_type": "measured",
-        "_FillValue": {"type": "double", "data": -1}
-      }
-    },
-    "pseudogram_depth": {
-      "type": "double",
-      "attributes": {
-        "units": "m",
-        "long_name": "Pseudogram Depth",
-        "valid_min": 0.0,
-        "valid_max": 2000.0,
-        "ioos_category": "Other",
-        "standard_name": "pseudogram_depth",
-        "platform": "platform",
-        "observation_type": "measured",
-        "_FillValue": {"type": "double", "data": -9999.9}
-      }
-    },
     "pseudogram_sv": {
+      "shape": ["time"],
       "type": "double",
       "attributes": {
         "units": "db",
@@ -1041,7 +1017,6 @@
         "standard_name": "pseudogram_sv",
         "platform": "platform",
         "observation_type": "measured",
-        "coordinates": "pseudogram_time pseudogram_depth",
         "_FillValue": {"type": "double", "data": -9999.9}
       }
     }

--- a/gutils/tests/resources/slocum/ecometrics/config/deployment.json
+++ b/gutils/tests/resources/slocum/ecometrics/config/deployment.json
@@ -1,6 +1,16 @@
 {
     "glider": "ecometrics",
     "trajectory_date": "20220212T0000",
+    "extra_kwargs": {
+        "pseudograms": {
+            "enable_nc": false,
+            "enable_ascii": false,
+            "enable_image": false,
+            "echosounderRange": 60.0,
+            "echosounderDirection": "up",
+            "echosounderRangeUnits": "meters"
+        }
+    },
     "attributes": {
         "acknowledgement": "This work was supported by funding from NOAA/IOOS/AOOS.",
         "comment": "",

--- a/gutils/tests/resources/slocum/ecometrics2/config/deployment.json
+++ b/gutils/tests/resources/slocum/ecometrics2/config/deployment.json
@@ -1,6 +1,16 @@
 {
     "glider": "ecometrics",
     "trajectory_date": "20220212T0000",
+    "extra_kwargs": {
+        "pseudograms": {
+            "enable_nc": true,
+            "enable_ascii": true,
+            "enable_image": false,
+            "echosounderRange": 60.0,
+            "echosounderDirection": "down",
+            "echosounderRangeUnits": "meters"
+        }
+    },
     "attributes": {
         "acknowledgement": "This work was supported by funding from NOAA/IOOS/AOOS.",
         "comment": "",
@@ -35,15 +45,6 @@
         "support_type": "ra,federal,federal",
         "title": "G507 Slocum Glider Dataset (Feb 2022)",
         "wmo_id": 4802989
-    },
-    "extra_kwargs": {
-        "pseudograms": {
-            "enable": true,
-            "create_images": false,
-            "echosounderRange": 60.0,
-            "echosounderDirection": "down",
-            "echosounderRangeUnits": "meters"
-        }
     },
     "variables": {
         "platform": {

--- a/gutils/tests/resources/slocum/ecometrics3/config/deployment.json
+++ b/gutils/tests/resources/slocum/ecometrics3/config/deployment.json
@@ -8,6 +8,16 @@
         "filter_points": 5,
         "filter_distance": 1
     },
+    "extra_kwargs": {
+        "pseudograms": {
+            "enable_nc": false,
+            "enable_ascii": false,
+            "enable_image": false,
+            "echosounderRange": 60.0,
+            "echosounderDirection": "up",
+            "echosounderRangeUnits": "meters"
+        }
+    },
     "attributes": {
         "acknowledgement": "This work was supported by funding from NOAA/IOOS/AOOS.",
         "comment": "",
@@ -42,15 +52,6 @@
         "support_type": "ra,federal,federal",
         "title": "G507 Slocum Glider Dataset (Feb 2022)",
         "wmo_id": 4802989
-    },
-    "extra_kwargs": {
-        "pseudograms": {
-            "enable": false,
-            "create_images": true,
-            "echosounderRange": 60.0,
-            "echosounderDirection": "up",
-            "echosounderRangeUnits": "meters"
-        }
     },
     "variables": {
         "platform": {

--- a/gutils/tests/resources/slocum/ecometrics4/config/deployment.json
+++ b/gutils/tests/resources/slocum/ecometrics4/config/deployment.json
@@ -8,6 +8,16 @@
         "filter_points": 5,
         "filter_distance": 1
     },
+    "extra_kwargs": {
+        "pseudograms": {
+            "enable_nc": false,
+            "enable_ascii": true,
+            "enable_image": false,
+            "echosounderRange": 60.0,
+            "echosounderDirection": "up",
+            "echosounderRangeUnits": "meters"
+        }
+    },
     "attributes": {
         "acknowledgement": "This work was supported by funding from NOAA/IOOS/AOOS.",
         "comment": "",
@@ -42,15 +52,6 @@
         "support_type": "ra,federal,federal",
         "title": "G507 Slocum Glider Dataset (Feb 2022)",
         "wmo_id": 4802989
-    },
-    "extra_kwargs": {
-        "pseudograms": {
-            "enable": true,
-            "create_images": false,
-            "echosounderRange": 60.0,
-            "echosounderDirection": "up",
-            "echosounderRangeUnits": "meters"
-        }
     },
     "variables": {
         "platform": {

--- a/gutils/tests/test_slocum.py
+++ b/gutils/tests/test_slocum.py
@@ -393,17 +393,19 @@ class TestEcoMetricsTwo(GutilsTestClass):
 
         output_files = sorted(os.listdir(self.netcdf_path))
         output_files = [ os.path.join(self.netcdf_path, o) for o in output_files ]
-        assert len(output_files) == 17
+        assert len(output_files) == 33
 
         # First profile
         with nc4.Dataset(output_files[0]) as ncd:
             assert ncd.variables['profile_id'].ndim == 0
+            # first time in the first profile
             assert ncd.variables['profile_id'][0] == 1639020410
 
         # Last profile
         with nc4.Dataset(output_files[-1]) as ncd:
             assert ncd.variables['profile_id'].ndim == 0
-            assert ncd.variables['profile_id'][0] == 1639069272
+            # first time in the last ecodroid profile
+            assert ncd.variables['profile_id'][0] == 1639070632
 
         # Check netCDF file for compliance
         ds = namedtuple('Arguments', ['file'])

--- a/gutils/tests/test_slocum.py
+++ b/gutils/tests/test_slocum.py
@@ -393,7 +393,7 @@ class TestEcoMetricsTwo(GutilsTestClass):
 
         output_files = sorted(os.listdir(self.netcdf_path))
         output_files = [ os.path.join(self.netcdf_path, o) for o in output_files ]
-        assert len(output_files) == 33
+        assert len(output_files) == 32
 
         # First profile
         with nc4.Dataset(output_files[0]) as ncd:


### PR DESCRIPTION
This assumes that the "extras" data occurs before or after a profile
and for now I think that is OK. This reduces the complexity of the
code quite a bit. We just make the "extras" data look like a profile
dataset, optionally setting the depths to zero if there are no depths
to capture the data as surface measurements.

This also changes some of the extras configuration kwarg names so we
can control the creation of the ASCII pseudogram and the inclustion
of that data into the netCDF profile files, and the image creation.