### PR TITLE
Updates container labels and copyright year

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM phusion/baseimage:focal-1.2.0
 
-LABEL maintainer="Kyle Wilcox <kyle@axiomdatascience.com>" \
-      description='The GUTILS container'
+LABEL org.opencontainers.image.description="GUTILS as a docker image."
+LABEL org.opencontainers.image.authors="Kyle Wilcox <kyle@axiomdatascience.com>"
+LABEL org.opencontainers.image.url="https://git.axiom/SECOORA/GUTILS/"
+LABEL org.opencontainers.image.source="https://git.axiom/SECOORA/GUTILS/"
+LABEL org.opencontainers.image.licenses="MIT"
+
 
 # Use baseimage-docker's init system
 CMD ["/sbin/my_init"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2022 Axiom Data Science
+Copyright (C) 2023 Axiom Data Science, LLC.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This commit updates the labels within the docker image to reflect the opencontainers standard for metadata available within the image. This allows users of the image to rapidly identify where the source code, and the contact information for maintainers, contributors, as well as the license of the source code.