### PR TITLE
Adds a README for the slcoum binary files

### DIFF
--- a/gutils/slocum/bin/README.md
+++ b/gutils/slocum/bin/README.md
@@ -1,0 +1,15 @@
+Slocum Binary Files
+-------------------
+
+This directory contains several binary files for Linux x86 which are used to
+process, parse, and translate the raw glider-provided data files. These files
+are distributed as part of the SFMC Software package and have been provided
+here by permission of SECOORA DMAC.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This commit adds a README explaining what the files are and where they originate from. As well as some basic license expressing limited liability.